### PR TITLE
Integrate MLA attention

### DIFF
--- a/encoder-pretrain/models/custom_bert.py
+++ b/encoder-pretrain/models/custom_bert.py
@@ -51,6 +51,8 @@ from transformers.modeling_utils import PreTrainedModel
 from transformers.pytorch_utils import apply_chunking_to_forward, find_pruneable_heads_and_indices, prune_linear_layer
 from transformers.utils import ModelOutput, auto_docstring, get_torch_version, logging
 from .configuration_bert import BertConfig
+from .layers.mla_attention import DeepseekV3Attention
+from .layers.configuration_deepseek_v3 import DeepseekV3Config
 
 
 
@@ -446,15 +448,29 @@ class BertSelfOutput(nn.Module):
 BERT_SELF_ATTENTION_CLASSES = {
     "eager": BertSelfAttention,
     "sdpa": BertSdpaSelfAttention,
+    "mla": DeepseekV3Attention,
 }
 
 
 class BertAttention(nn.Module):
     def __init__(self, config, position_embedding_type=None):
         super().__init__()
-        self.self = BERT_SELF_ATTENTION_CLASSES[config._attn_implementation](
-            config, position_embedding_type=position_embedding_type
-        )
+        attn_cls = BERT_SELF_ATTENTION_CLASSES[config._attn_implementation]
+        if attn_cls is DeepseekV3Attention:
+            ds_config = DeepseekV3Config(
+                hidden_size=config.hidden_size,
+                intermediate_size=config.intermediate_size,
+                num_hidden_layers=config.num_hidden_layers,
+                num_attention_heads=config.num_attention_heads,
+                num_key_value_heads=config.num_attention_heads,
+                max_position_embeddings=config.max_position_embeddings,
+                attention_dropout=config.attention_probs_dropout_prob,
+                rms_norm_eps=config.layer_norm_eps,
+            )
+            ds_config.o_lora_rank = config.hidden_size
+            self.self = attn_cls(ds_config, layer_idx=0)
+        else:
+            self.self = attn_cls(config, position_embedding_type=position_embedding_type)
         self.output = BertSelfOutput(config)
         self.pruned_heads = set()
 

--- a/encoder-pretrain/models/layers/cache_utils.py
+++ b/encoder-pretrain/models/layers/cache_utils.py
@@ -11,8 +11,8 @@ from packaging import version
 
 from transformers.pytorch_utils import is_torch_greater_or_equal_than_2_6
 
-from .configuration_utils import PretrainedConfig
-from .utils import is_hqq_available, is_optimum_quanto_available, is_torch_greater_or_equal, logging
+from transformers.configuration_utils import PretrainedConfig
+from transformers.utils import is_hqq_available, is_optimum_quanto_available, is_torch_greater_or_equal, logging
 
 
 if is_hqq_available():

--- a/encoder-pretrain/models/layers/configuration_deepseek_v3.py
+++ b/encoder-pretrain/models/layers/configuration_deepseek_v3.py
@@ -16,8 +16,8 @@
 # limitations under the License.
 """DeepSeekV3 model configuration"""
 
-from ...configuration_utils import PretrainedConfig
-from ...modeling_rope_utils import rope_config_validation
+from transformers.configuration_utils import PretrainedConfig
+from transformers.modeling_rope_utils import rope_config_validation
 
 
 DEEPSEEK_PRETRAINED_CONFIG_ARCHIVE_MAP = {}

--- a/encoder-pretrain/models/layers/mla_attention.py
+++ b/encoder-pretrain/models/layers/mla_attention.py
@@ -13,17 +13,17 @@ from transformers.activations import ACT2FN
 from transformers.modeling_outputs import BaseModelOutputWithPast
 from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS, dynamic_rope_update
 from transformers.utils import logging
+from transformers.modeling_flash_attention_utils import FlashAttentionKwargs
+from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
 
 # Local modules (copied into repo)
 from models.layers.cache_utils import Cache, DynamicCache
 from models.layers.configuration_deepseek_v3 import DeepseekV3Config
 
 # 🟡 Optional: For future support (still unused unless you reintroduce dynamic attention backend)
-# from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
 
 # Removed:
 # from ...generation import GenerationMixin
-# from ...integrations import use_kernel_forward_from_hub
 # from ...masking_utils import create_causal_mask
 # from ...modeling_flash_attention_utils import FlashAttentionKwargs
 # from ...modeling_layers import GradientCheckpointingLayer
@@ -31,14 +31,12 @@ from models.layers.configuration_deepseek_v3 import DeepseekV3Config
 # from ...processing_utils import Unpack
 # from ...utils import LossKwargs, auto_docstring, can_return_tuple
 
-!wget -q -O local_hf/cache_utils.py https://github.com/huggingface/transformers/raw/refs/tags/v4.53.3/src/transformers/cache_utils.py
-!wget -q -O local_hf/configuration_deepseek_v3.py https://github.com/huggingface/transformers/raw/refs/tags/v4.53.3/src/transformers/models/deepseek_v3/configuration_deepseek_v3.py
-
 
 logger = logging.get_logger(__name__)
 
 
-@use_kernel_forward_from_hub("RMSNorm")
+# Optional JIT kernel; harmless to disable if unavailable
+# @use_kernel_forward_from_hub("RMSNorm")
 class DeepseekV3RMSNorm(nn.Module):
     def __init__(self, hidden_size, eps=1e-6):
         """
@@ -245,6 +243,10 @@ class DeepseekV3Attention(nn.Module):
         self.qk_nope_head_dim = config.qk_nope_head_dim
         self.qk_head_dim = config.qk_head_dim
 
+        # Additional attributes used by our MLA variant
+        self.hidden_size = config.hidden_size
+        self.o_lora_rank = getattr(config, "o_lora_rank", config.hidden_size)
+
         self.is_causal = True
         if self.q_lora_rank is None:
             self.q_proj = nn.Linear(config.hidden_size, self.num_heads * self.qk_head_dim, bias=False)
@@ -297,7 +299,7 @@ class DeepseekV3Attention(nn.Module):
         attention_mask: Optional[torch.Tensor],
         past_key_value: Optional[Cache] = None,
         cache_position: Optional[torch.LongTensor] = None,
-        **kwargs: Unpack[FlashAttentionKwargs],
+        **kwargs,
     ) -> tuple[torch.Tensor, Optional[torch.Tensor], Optional[tuple[torch.Tensor]]]:
         batch_size, seq_length = hidden_states.shape[:-1]
         query_shape = (batch_size, seq_length, -1, self.qk_head_dim)


### PR DESCRIPTION
## Summary
- fix imports for local copies of DeepSeek modules
- remove stray Jupyter shell lines in `mla_attention.py`
- wire DeepSeekV3Attention into custom BERT and supply minimal config

## Testing
- `python -m py_compile encoder-pretrain/models/*.py encoder-pretrain/models/layers/*.py`
- `python - <<'PY'
import sys
sys.path.append('encoder-pretrain')
from models.custom_bert import BertAttention
from models.configuration_bert import BertConfig
cfg=BertConfig();cfg._attn_implementation='mla'
attn=BertAttention(cfg)
print('attention', type(attn.self))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68890e453f64832a9c4af9ca534e47a4