### PR TITLE
Add sanity tests for BERT and MLA

### DIFF
--- a/encoder-pretrain/tests/test_sanity.py
+++ b/encoder-pretrain/tests/test_sanity.py
@@ -1,0 +1,179 @@
+import torch
+import pytest
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from models.custom_bert import BertForMaskedLM, BertConfig
+from models.layers.mla_attention import (
+    DeepseekV3Attention,
+    DeepseekV3Config,
+    DeepseekV3RotaryEmbedding,
+)
+
+
+def test_custom_bert_forward():
+    config = BertConfig(
+        vocab_size=100,
+        hidden_size=32,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        intermediate_size=64,
+    )
+    # Use standard attention implementation
+    config._attn_implementation = "eager"
+    model = BertForMaskedLM(config)
+    # generate random input ids (batch_size=2, seq_len=8)
+    input_ids = torch.randint(0, config.vocab_size, (2, 8))
+    outputs = model(input_ids=input_ids)
+    assert outputs.logits.shape == (2, 8, config.vocab_size)
+
+
+def test_deepseek_attention_forward():
+    ds_config = DeepseekV3Config(
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        kv_lora_rank=8,
+        q_lora_rank=8,
+        qk_rope_head_dim=16,
+        qk_nope_head_dim=8,
+        v_head_dim=16,
+        max_position_embeddings=16,
+        attention_dropout=0.0,
+        rms_norm_eps=1e-6,
+    )
+    ds_config.add_output_latent = False
+    ds_config._attn_implementation = "eager"
+    attention = DeepseekV3Attention(ds_config, layer_idx=0)
+
+    rotary = DeepseekV3RotaryEmbedding(ds_config)
+    position_ids = torch.arange(0, 8).unsqueeze(0)
+    dummy = torch.zeros(1, 1, ds_config.qk_rope_head_dim)
+    cos, sin = rotary(dummy, position_ids)
+
+    # random hidden states: (batch=2, seq_len=8, hidden_size)
+    hidden_states = torch.randn(2, 8, ds_config.hidden_size)
+    # full attention mask (batch=2, heads=1, seq=1, kv_seq=8)
+    attn_mask = torch.ones(2, 1, 1, 8)
+    out, _ = attention(hidden_states, (cos, sin), attn_mask)
+    assert out.shape == (2, 8, ds_config.hidden_size)
+
+
+def test_deepseek_attention_with_output_latent():
+    ds_config = DeepseekV3Config(
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        kv_lora_rank=8,
+        q_lora_rank=8,
+        qk_rope_head_dim=16,
+        qk_nope_head_dim=8,
+        v_head_dim=16,
+        max_position_embeddings=16,
+        attention_dropout=0.0,
+        rms_norm_eps=1e-6,
+    )
+    ds_config.add_output_latent = True
+    ds_config.o_lora_rank = ds_config.hidden_size
+    ds_config._attn_implementation = "eager"
+    attention = DeepseekV3Attention(ds_config, layer_idx=0)
+
+    assert hasattr(attention, "o_a_proj")
+    assert hasattr(attention, "o_b_proj")
+
+    rotary = DeepseekV3RotaryEmbedding(ds_config)
+    position_ids = torch.arange(0, 8).unsqueeze(0)
+    dummy = torch.zeros(1, 1, ds_config.qk_rope_head_dim)
+    cos, sin = rotary(dummy, position_ids)
+
+    hidden_states = torch.randn(2, 8, ds_config.hidden_size)
+    attn_mask = torch.ones(2, 1, 1, 8)
+    out, _ = attention(hidden_states, (cos, sin), attn_mask)
+    assert out.shape == (2, 8, ds_config.hidden_size)
+
+
+def test_deepseek_attention_flash():
+    ds_config = DeepseekV3Config(
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        kv_lora_rank=8,
+        q_lora_rank=8,
+        qk_rope_head_dim=16,
+        qk_nope_head_dim=8,
+        v_head_dim=16,
+        max_position_embeddings=16,
+        attention_dropout=0.0,
+        rms_norm_eps=1e-6,
+    )
+    ds_config.add_output_latent = False
+    ds_config._attn_implementation = "flash_attention_2"
+    attention = DeepseekV3Attention(ds_config, layer_idx=0)
+
+    rotary = DeepseekV3RotaryEmbedding(ds_config)
+    position_ids = torch.arange(0, 8).unsqueeze(0)
+    dummy = torch.zeros(1, 1, ds_config.qk_rope_head_dim)
+    cos, sin = rotary(dummy, position_ids)
+
+    hidden_states = torch.randn(2, 8, ds_config.hidden_size)
+    attn_mask = torch.ones(2, 1, 1, 8)
+    out, _ = attention(hidden_states, (cos, sin), attn_mask)
+    assert out.shape == (2, 8, ds_config.hidden_size)
+
+
+def test_custom_bert_with_mla():
+    config = BertConfig(
+        vocab_size=100,
+        hidden_size=32,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        intermediate_size=64,
+    )
+    config._attn_implementation = "mla"
+    config.add_output_latent = False
+    model = BertForMaskedLM(config)
+    input_ids = torch.randint(0, config.vocab_size, (2, 8))
+    outputs = model(input_ids=input_ids)
+    assert outputs.logits.shape == (2, 8, config.vocab_size)
+
+
+def test_custom_bert_with_mla_output_latent():
+    config = BertConfig(
+        vocab_size=100,
+        hidden_size=32,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        intermediate_size=64,
+    )
+    config._attn_implementation = "mla"
+    config.add_output_latent = True
+    model = BertForMaskedLM(config)
+    input_ids = torch.randint(0, config.vocab_size, (2, 8))
+    outputs = model(input_ids=input_ids)
+    assert outputs.logits.shape == (2, 8, config.vocab_size)
+
+
+if __name__ == "__main__":
+    print("Testing standard BERT forward")
+    test_custom_bert_forward()
+    print("Testing MLA attention forward")
+    test_deepseek_attention_forward()
+    print("Testing MLA with output latent")
+    test_deepseek_attention_with_output_latent()
+    print("Testing MLA flash attention")
+    test_deepseek_attention_flash()
+    print("Testing BERT with MLA")
+    test_custom_bert_with_mla()
+    print("Testing BERT with MLA and output latent")
+    test_custom_bert_with_mla_output_latent()
+


### PR DESCRIPTION
## Summary
- expand `test_sanity.py` with BERT MLA checks and flash attention
- verify the output latent modules exist when enabled
- call each test when run as a script

## Testing
- `pytest -q encoder-pretrain/tests/test_sanity.py` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_688929eb1a60832aa4a9efaf0183782f