### PR TITLE
Set output latent config in Deepseek

### DIFF
--- a/encoder-pretrain/models/custom_bert.py
+++ b/encoder-pretrain/models/custom_bert.py
@@ -491,7 +491,6 @@ class BertAttention(nn.Module):
                 attention_dropout=config.attention_probs_dropout_prob,
                 rms_norm_eps=config.layer_norm_eps,
             )
-            ds_config.add_output_latent = config.add_output_latent
             ds_config._attn_implementation = config._attn_implementation
             self.self = attn_cls(ds_config, layer_idx=0)
             self.rotary_emb = DeepseekV3RotaryEmbedding(ds_config)

--- a/encoder-pretrain/models/layers/configuration_deepseek_v3.py
+++ b/encoder-pretrain/models/layers/configuration_deepseek_v3.py
@@ -213,6 +213,15 @@ class DeepseekV3Config(PretrainedConfig):
         self.qk_rope_head_dim = qk_rope_head_dim
         self.v_head_dim = v_head_dim
         self.qk_nope_head_dim = qk_nope_head_dim
+        # ------------------------------------------------
+        # Modified: store output latent options on the config
+        # so they don't need to be manually overridden later.
+        self.use_output_latent = use_output_latent
+        # Keep backwards compatibility with older code that
+        # checks `add_output_latent`.
+        self.add_output_latent = use_output_latent
+        self.o_lora_rank = o_lora_rank
+        # ------------------------------------------------
         self.qk_head_dim = qk_nope_head_dim + qk_rope_head_dim
         self.head_dim = qk_rope_head_dim
         self.n_group = n_group

--- a/encoder-pretrain/tests/test_sanity.py
+++ b/encoder-pretrain/tests/test_sanity.py
@@ -48,7 +48,6 @@ def test_deepseek_attention_forward():
         attention_dropout=0.0,
         rms_norm_eps=1e-6,
     )
-    ds_config.add_output_latent = False
     ds_config._attn_implementation = "eager"
     attention = DeepseekV3Attention(ds_config, layer_idx=0)
 
@@ -80,9 +79,9 @@ def test_deepseek_attention_with_output_latent():
         max_position_embeddings=16,
         attention_dropout=0.0,
         rms_norm_eps=1e-6,
+        use_output_latent=True,
+        o_lora_rank=32,
     )
-    ds_config.add_output_latent = True
-    ds_config.o_lora_rank = ds_config.hidden_size
     ds_config._attn_implementation = "eager"
     attention = DeepseekV3Attention(ds_config, layer_idx=0)
 
@@ -117,7 +116,6 @@ def test_deepseek_attention_flash():
         attention_dropout=0.0,
         rms_norm_eps=1e-6,
     )
-    ds_config.add_output_latent = False
     ds_config._attn_implementation = "flash_attention_2"
     attention = DeepseekV3Attention(ds_config, layer_idx=0)
 


### PR DESCRIPTION
## Summary
- store `use_output_latent` and `o_lora_rank` on `DeepseekV3Config`
- stop manually overriding attributes in `custom_bert` and tests
- update tests to pass configuration via constructor

## Testing
- `pytest -q encoder-pretrain/tests/test_sanity.py::test_deepseek_attention_with_output_latent -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68895485e768832aa758eb2f23f19e2d