### PR TITLE
Rename BERT model to SubspaceBert

### DIFF
--- a/encoder-pretrain/models/configuration_bert.py
+++ b/encoder-pretrain/models/configuration_bert.py
@@ -26,12 +26,11 @@ from transformers.utils import logging
 logger = logging.get_logger(__name__)
 
 
-class BertConfig(PretrainedConfig):
+class SubspaceBertConfig(PretrainedConfig):
     r"""
-    This is the configuration class to store the configuration of a [`BertModel`] or a [`TFBertModel`]. It is used to
-    instantiate a BERT model according to the specified arguments, defining the model architecture. Instantiating a
-    configuration with the defaults will yield a similar configuration to that of the BERT
-    [google-bert/bert-base-uncased](https://huggingface.co/google-bert/bert-base-uncased) architecture.
+    Configuration class for the `SubspaceBertModel`.  This is copied from
+    HuggingFace's `BertConfig` and extended with additional options used in this
+    project (e.g. Multihead Latent Attention).
 
     Configuration objects inherit from [`PretrainedConfig`] and can be used to control the model outputs. Read the
     documentation from [`PretrainedConfig`] for more information.
@@ -160,7 +159,7 @@ class BertConfig(PretrainedConfig):
         # ------------------------------------------------
 
 
-class BertOnnxConfig(OnnxConfig):
+class SubspaceBertOnnxConfig(OnnxConfig):
     @property
     def inputs(self) -> Mapping[str, Mapping[int, str]]:
         if self.task == "multiple-choice":
@@ -176,4 +175,11 @@ class BertOnnxConfig(OnnxConfig):
         )
 
 
-__all__ = ["BertConfig", "BertOnnxConfig"]
+__all__ = ["SubspaceBertConfig", "SubspaceBertOnnxConfig"]
+
+# ---------------------------------------------------------------------------
+# Aliases for backward compatibility with earlier code referencing `BertConfig`
+# and `BertOnnxConfig` directly.  This keeps old imports working while we
+# transition to the new `SubspaceBert*` names.
+BertConfig = SubspaceBertConfig
+BertOnnxConfig = SubspaceBertOnnxConfig

--- a/encoder-pretrain/models/custom_bert.py
+++ b/encoder-pretrain/models/custom_bert.py
@@ -50,7 +50,7 @@ from transformers.modeling_outputs import (
 from transformers.modeling_utils import PreTrainedModel
 from transformers.pytorch_utils import apply_chunking_to_forward, find_pruneable_heads_and_indices, prune_linear_layer
 from transformers.utils import ModelOutput, auto_docstring, get_torch_version, logging
-from .configuration_bert import BertConfig
+from .configuration_bert import SubspaceBertConfig
 # -------------------------------------------------------------
 # Modified: Import DeepSeek MLA components used in our custom mode.
 from .layers.mla_attention import DeepseekV3Attention, DeepseekV3RotaryEmbedding
@@ -842,8 +842,8 @@ class BertPreTrainingHeads(nn.Module):
 
 
 @auto_docstring
-class BertPreTrainedModel(PreTrainedModel):
-    config_class = BertConfig
+class SubspaceBertPreTrainedModel(PreTrainedModel):
+    config_class = SubspaceBertConfig
     load_tf_weights = load_tf_weights_in_bert
     base_model_prefix = "bert"
     supports_gradient_checkpointing = True
@@ -874,7 +874,7 @@ class BertPreTrainedModel(PreTrainedModel):
     Output type of [`BertForPreTraining`].
     """
 )
-class BertForPreTrainingOutput(ModelOutput):
+class SubspaceBertForPreTrainingOutput(ModelOutput):
     r"""
     loss (*optional*, returned when `labels` is provided, `torch.FloatTensor` of shape `(1,)`):
         Total loss as the sum of the masked language modeling loss and the next sequence prediction
@@ -905,7 +905,7 @@ class BertForPreTrainingOutput(ModelOutput):
     `add_cross_attention` set to `True`; an `encoder_hidden_states` is then expected as an input to the forward pass.
     """
 )
-class BertModel(BertPreTrainedModel):
+class SubspaceBertModel(SubspaceBertPreTrainedModel):
     _no_split_modules = ["BertEmbeddings", "BertLayer"]
 
     def __init__(self, config, add_pooling_layer=True):
@@ -1091,13 +1091,13 @@ class BertModel(BertPreTrainedModel):
     sentence prediction (classification)` head.
     """
 )
-class BertForPreTraining(BertPreTrainedModel):
+class SubspaceBertForPreTraining(SubspaceBertPreTrainedModel):
     _tied_weights_keys = ["predictions.decoder.bias", "cls.predictions.decoder.weight"]
 
     def __init__(self, config):
         super().__init__(config)
 
-        self.bert = BertModel(config)
+        self.bert = SubspaceBertModel(config)
         self.cls = BertPreTrainingHeads(config)
 
         # Initialize weights and apply final processing
@@ -1124,7 +1124,7 @@ class BertForPreTraining(BertPreTrainedModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
-    ) -> Union[tuple[torch.Tensor], BertForPreTrainingOutput]:
+    ) -> Union[tuple[torch.Tensor], SubspaceBertForPreTrainingOutput]:
         r"""
         labels (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
             Labels for computing the masked language modeling loss. Indices should be in `[-100, 0, ...,
@@ -1181,7 +1181,7 @@ class BertForPreTraining(BertPreTrainedModel):
             output = (prediction_scores, seq_relationship_score) + outputs[2:]
             return ((total_loss,) + output) if total_loss is not None else output
 
-        return BertForPreTrainingOutput(
+        return SubspaceBertForPreTrainingOutput(
             loss=total_loss,
             prediction_logits=prediction_scores,
             seq_relationship_logits=seq_relationship_score,
@@ -1195,7 +1195,7 @@ class BertForPreTraining(BertPreTrainedModel):
     Bert Model with a `language modeling` head on top for CLM fine-tuning.
     """
 )
-class BertLMHeadModel(BertPreTrainedModel, GenerationMixin):
+class SubspaceBertLMHeadModel(SubspaceBertPreTrainedModel, GenerationMixin):
     _tied_weights_keys = ["cls.predictions.decoder.bias", "cls.predictions.decoder.weight"]
 
     def __init__(self, config):
@@ -1204,7 +1204,7 @@ class BertLMHeadModel(BertPreTrainedModel, GenerationMixin):
         if not config.is_decoder:
             logger.warning("If you want to use `BertLMHeadModel` as a standalone, add `is_decoder=True.`")
 
-        self.bert = BertModel(config, add_pooling_layer=False)
+        self.bert = SubspaceBertModel(config, add_pooling_layer=False)
         self.cls = BertOnlyMLMHead(config)
 
         # Initialize weights and apply final processing
@@ -1292,7 +1292,7 @@ class BertLMHeadModel(BertPreTrainedModel, GenerationMixin):
 
 
 @auto_docstring
-class BertForMaskedLM(BertPreTrainedModel):
+class SubspaceBertForMaskedLM(SubspaceBertPreTrainedModel):
     _tied_weights_keys = ["predictions.decoder.bias", "cls.predictions.decoder.weight"]
 
     def __init__(self, config):
@@ -1304,7 +1304,7 @@ class BertForMaskedLM(BertPreTrainedModel):
                 "bi-directional self-attention."
             )
 
-        self.bert = BertModel(config, add_pooling_layer=False)
+        self.bert = SubspaceBertModel(config, add_pooling_layer=False)
         self.cls = BertOnlyMLMHead(config)
 
         # Initialize weights and apply final processing
@@ -1405,11 +1405,11 @@ class BertForMaskedLM(BertPreTrainedModel):
     Bert Model with a `next sentence prediction (classification)` head on top.
     """
 )
-class BertForNextSentencePrediction(BertPreTrainedModel):
+class SubspaceBertForNextSentencePrediction(SubspaceBertPreTrainedModel):
     def __init__(self, config):
         super().__init__(config)
 
-        self.bert = BertModel(config)
+        self.bert = SubspaceBertModel(config)
         self.cls = BertOnlyNSPHead(config)
 
         # Initialize weights and apply final processing
@@ -1506,13 +1506,13 @@ class BertForNextSentencePrediction(BertPreTrainedModel):
     output) e.g. for GLUE tasks.
     """
 )
-class BertForSequenceClassification(BertPreTrainedModel):
+class SubspaceBertForSequenceClassification(SubspaceBertPreTrainedModel):
     def __init__(self, config):
         super().__init__(config)
         self.num_labels = config.num_labels
         self.config = config
 
-        self.bert = BertModel(config)
+        self.bert = SubspaceBertModel(config)
         classifier_dropout = (
             config.classifier_dropout if config.classifier_dropout is not None else config.hidden_dropout_prob
         )
@@ -1596,11 +1596,11 @@ class BertForSequenceClassification(BertPreTrainedModel):
 
 
 @auto_docstring
-class BertForMultipleChoice(BertPreTrainedModel):
+class SubspaceBertForMultipleChoice(SubspaceBertPreTrainedModel):
     def __init__(self, config):
         super().__init__(config)
 
-        self.bert = BertModel(config)
+        self.bert = SubspaceBertModel(config)
         classifier_dropout = (
             config.classifier_dropout if config.classifier_dropout is not None else config.hidden_dropout_prob
         )
@@ -1703,12 +1703,12 @@ class BertForMultipleChoice(BertPreTrainedModel):
 
 
 @auto_docstring
-class BertForTokenClassification(BertPreTrainedModel):
+class SubspaceBertForTokenClassification(SubspaceBertPreTrainedModel):
     def __init__(self, config):
         super().__init__(config)
         self.num_labels = config.num_labels
 
-        self.bert = BertModel(config, add_pooling_layer=False)
+        self.bert = SubspaceBertModel(config, add_pooling_layer=False)
         classifier_dropout = (
             config.classifier_dropout if config.classifier_dropout is not None else config.hidden_dropout_prob
         )
@@ -1773,12 +1773,12 @@ class BertForTokenClassification(BertPreTrainedModel):
 
 
 @auto_docstring
-class BertForQuestionAnswering(BertPreTrainedModel):
+class SubspaceBertForQuestionAnswering(SubspaceBertPreTrainedModel):
     def __init__(self, config):
         super().__init__(config)
         self.num_labels = config.num_labels
 
-        self.bert = BertModel(config, add_pooling_layer=False)
+        self.bert = SubspaceBertModel(config, add_pooling_layer=False)
         self.qa_outputs = nn.Linear(config.hidden_size, config.num_labels)
 
         # Initialize weights and apply final processing
@@ -1851,16 +1851,31 @@ class BertForQuestionAnswering(BertPreTrainedModel):
 
 
 __all__ = [
-    "BertForMaskedLM",
-    "BertForMultipleChoice",
-    "BertForNextSentencePrediction",
-    "BertForPreTraining",
-    "BertForQuestionAnswering",
-    "BertForSequenceClassification",
-    "BertForTokenClassification",
+    "SubspaceBertForMaskedLM",
+    "SubspaceBertForMultipleChoice",
+    "SubspaceBertForNextSentencePrediction",
+    "SubspaceBertForPreTraining",
+    "SubspaceBertForQuestionAnswering",
+    "SubspaceBertForSequenceClassification",
+    "SubspaceBertForTokenClassification",
     "BertLayer",
-    "BertLMHeadModel",
-    "BertModel",
-    "BertPreTrainedModel",
+    "SubspaceBertLMHeadModel",
+    "SubspaceBertModel",
+    "SubspaceBertPreTrainedModel",
     "load_tf_weights_in_bert",
 ]
+
+# ---------------------------------------------------------------------------
+# Aliases so existing code referring to the old BERT class names continues to
+# function.  This allows a gradual transition to the new `SubspaceBert*` names.
+BertPreTrainedModel = SubspaceBertPreTrainedModel
+BertModel = SubspaceBertModel
+BertForPreTraining = SubspaceBertForPreTraining
+BertLMHeadModel = SubspaceBertLMHeadModel
+BertForMaskedLM = SubspaceBertForMaskedLM
+BertForNextSentencePrediction = SubspaceBertForNextSentencePrediction
+BertForSequenceClassification = SubspaceBertForSequenceClassification
+BertForMultipleChoice = SubspaceBertForMultipleChoice
+BertForTokenClassification = SubspaceBertForTokenClassification
+BertForQuestionAnswering = SubspaceBertForQuestionAnswering
+BertForPreTrainingOutput = SubspaceBertForPreTrainingOutput

--- a/encoder-pretrain/scripts/train.py
+++ b/encoder-pretrain/scripts/train.py
@@ -17,7 +17,7 @@ from transformers import (
     set_seed,
 )
 
-from transformers import AutoModelForMaskedLM, AutoConfig, BertConfig
+from models.custom_bert import SubspaceBertForMaskedLM, SubspaceBertConfig
 
 # Make sure we can import modules from the encoder-pretrain package
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
@@ -76,6 +76,11 @@ def main():
     with open(args.config) as f:
         cfg = json.load(f)
 
+    # Some keys in the configs have older names. Normalize them here so the rest
+    # of the script can rely on a consistent set of fields.
+    if "use_decomp_mlp" not in cfg:
+        cfg["use_decomp_mlp"] = cfg.get("ffn_decompose", False)
+
     print("Transformers version:", transformers.__version__)  # Helpful sanity check
 
     # Set random seed for reproducibility
@@ -127,7 +132,7 @@ def main():
 
     #model = CustomBertForMaskedLM.from_config(cfg)
 
-    bert_config = BertConfig(
+    bert_config = SubspaceBertConfig(
         vocab_size=cfg["vocab_size"],
         hidden_size=cfg["hidden_size"],
         num_hidden_layers=cfg["num_hidden_layers"],
@@ -138,9 +143,17 @@ def main():
         hidden_act=cfg.get("hidden_act", "gelu"),
         hidden_dropout_prob=cfg.get("hidden_dropout_prob", 0.1),
         attention_probs_dropout_prob=cfg.get("attention_probs_dropout_prob", 0.1),
+        use_mla=cfg.get("use_mla", False),
+        kv_lora_rank=cfg.get("kv_lora_rank"),
+        q_lora_rank=cfg.get("q_lora_rank"),
+        o_lora_rank=cfg.get("o_lora_rank"),
+        qk_rope_head_dim=cfg.get("qk_rope_head_dim"),
+        v_head_dim=cfg.get("v_head_dim"),
+        qk_nope_head_dim=cfg.get("qk_nope_head_dim"),
+        add_output_latent=cfg.get("use_output_latent", False),
     )
-    
-    model = AutoModelForMaskedLM.from_config(bert_config)
+
+    model = SubspaceBertForMaskedLM(bert_config)
     
     model
 
@@ -188,23 +201,42 @@ def main():
     lr_str = '{:.0e}'.format(cfg['learning_rate'])
 
     # Attention configuration
-    if cfg.use_mla:
-        dense_str = str(cfg.num_dense_layers) + "mha + "
+    if cfg.get("use_mla"):
+        dense_str = str(cfg.get("num_dense_layers")) + "mha + "
 
         # If no output subspace is used, the dimension will show as -1.
-        attn_str = dense_str + "mla." + str(cfg.q_lora_rank) + "." + str(cfg.kv_lora_rank) + "." + str(cfg.o_lora_rank)
+        attn_str = (
+            dense_str
+            + "mla."
+            + str(cfg.get("q_lora_rank"))
+            + "."
+            + str(cfg.get("kv_lora_rank"))
+            + "."
+            + str(cfg.get("o_lora_rank"))
+        )
     else:
         attn_str = "mha"
 
     # MLP Configuration
-    if cfg.use_decomp_mlp:
+    if cfg.get("use_decomp_mlp"):
         # Specify the number of dense mlps and their size.
-        dense_str = str(cfg.num_dense_layers) + "mlp." + str(cfg.intermediate_size) + " + "
+        dense_str = (
+            str(cfg.get("num_dense_layers"))
+            + "mlp."
+            + str(cfg.get("intermediate_size"))
+            + " + "
+        )
 
         # Specify the neuron count and latent dimension of the decomposed mlps.
-        mlp_str = dense_str + "dcmp." + str(cfg.mlp_num_neurons) + "." + str(cfg.mlp_latent_dim)
+        mlp_str = (
+            dense_str
+            + "dcmp."
+            + str(cfg.get("mlp_num_neurons"))
+            + "."
+            + str(cfg.get("mlp_latent_dim"))
+        )
     else:
-        mlp_str = "mlp." + str(cfg.mlp_num_neurons)
+        mlp_str = "mlp." + str(cfg.get("mlp_num_neurons"))
 
 
     run_name = f"{cfg['total_elements']} - {attn_str} - {mlp_str} - h{cfg['hidden_size']} - l{cfg['num_hidden_layers']} - bs{cfg['train_batch_size']} - lr{lr_str} - seq{cfg['max_seq_length']}"

--- a/encoder-pretrain/tests/test_sanity.py
+++ b/encoder-pretrain/tests/test_sanity.py
@@ -7,7 +7,7 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
-from models.custom_bert import BertForMaskedLM, BertConfig
+from models.custom_bert import SubspaceBertForMaskedLM, SubspaceBertConfig
 from models.layers.mla_attention import (
     DeepseekV3Attention,
     DeepseekV3Config,
@@ -16,7 +16,7 @@ from models.layers.mla_attention import (
 
 
 def test_custom_bert_forward():
-    config = BertConfig(
+    config = SubspaceBertConfig(
         vocab_size=100,
         hidden_size=32,
         num_hidden_layers=2,
@@ -25,7 +25,7 @@ def test_custom_bert_forward():
     )
     # Use standard attention implementation
     config._attn_implementation = "eager"
-    model = BertForMaskedLM(config)
+    model = SubspaceBertForMaskedLM(config)
     # generate random input ids (batch_size=2, seq_len=8)
     input_ids = torch.randint(0, config.vocab_size, (2, 8))
     outputs = model(input_ids=input_ids)
@@ -131,7 +131,7 @@ def test_deepseek_attention_flash():
 """
 
 def test_custom_bert_with_mla():
-    config = BertConfig(
+    config = SubspaceBertConfig(
         vocab_size=100,
         hidden_size=32,
         num_hidden_layers=2,
@@ -141,14 +141,14 @@ def test_custom_bert_with_mla():
     config._attn_implementation = "eager" # Allows for manual implementation.
     config.use_mla = True # Use this to choose MLA instead.
     config.add_output_latent = False
-    model = BertForMaskedLM(config)
+    model = SubspaceBertForMaskedLM(config)
     input_ids = torch.randint(0, config.vocab_size, (2, 8))
     outputs = model(input_ids=input_ids)
     assert outputs.logits.shape == (2, 8, config.vocab_size)
 
 
 def test_custom_bert_with_mla_output_latent():
-    config = BertConfig(
+    config = SubspaceBertConfig(
         vocab_size=100,
         hidden_size=32,
         num_hidden_layers=2,
@@ -158,7 +158,7 @@ def test_custom_bert_with_mla_output_latent():
     config._attn_implementation = "eager" # Allows for manual implementation.
     config.use_mla = True # Use this to choose MLA instead.
     config.add_output_latent = True
-    model = BertForMaskedLM(config)
+    model = SubspaceBertForMaskedLM(config)
     input_ids = torch.randint(0, config.vocab_size, (2, 8))
     outputs = model(input_ids=input_ids)
     assert outputs.logits.shape == (2, 8, config.vocab_size)


### PR DESCRIPTION
## Summary
- rename custom BERT config and model classes to `SubspaceBert*`
- keep backwards compatible aliases for old class names
- update unit tests for new imports
- update training script to use the new classes and mla config options

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68895be03db0832a9c4b823d523baec6