### PR TITLE
Persist run name in checkpoints

### DIFF
--- a/encoder-pretrain/scripts/finetune_sst2.py
+++ b/encoder-pretrain/scripts/finetune_sst2.py
@@ -16,7 +16,7 @@ from transformers.modeling_outputs import SequenceClassifierOutput
 
 #from transformers import BertForSequenceClassification
 
-from models.custom_bert import SubspaceBertForSequenceClassification
+from models.custom_bert import SubspaceBertForSequenceClassification, SubspaceBertConfig
 
 # Filter out some unhelpful warnings cluttering the output.
 import warnings
@@ -72,11 +72,14 @@ def main():
         "max_length": 128,
     }
 
-    # TODO... We need a way to pass the configuration string from the 
-    # checkpoint to this script.
+    # Retrieve the run name used during pre-training so we can reuse it here.
+    model_cfg = SubspaceBertConfig.from_pretrained(model_path)
+    run_name = getattr(model_cfg, "run_name", "pretrain")
+    config["run_name"] = run_name
+
     wandb.init(
-        project="encoder-pretrain", 
-        name="finetune-cola", 
+        project="encoder-pretrain",
+        name=f"{run_name}-sst2",
         config=config
     )
 

--- a/encoder-pretrain/scripts/train.py
+++ b/encoder-pretrain/scripts/train.py
@@ -298,6 +298,8 @@ def main():
 
     run_name = f"{cfg['total_elements']} - {attn_str} - {mlp_str} - h{cfg['hidden_size']} - l{cfg['num_hidden_layers']} - bs{cfg['train_batch_size']} - lr{lr_str} - seq{cfg['max_seq_length']}"
 
+    cfg["run_name"] = run_name
+    model.config.run_name = run_name
 
     print(run_name)
 


### PR DESCRIPTION
## Summary
- store `run_name` in the SubspaceBERT config during pretraining
- reuse the stored `run_name` when running `finetune_sst2.py`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68896c8c5070832aac4b075c0bb64f04