### PR TITLE
Add decomposed FFN option

### DIFF
--- a/encoder-pretrain/models/configuration_bert.py
+++ b/encoder-pretrain/models/configuration_bert.py
@@ -128,6 +128,10 @@ class SubspaceBertConfig(PretrainedConfig):
         # attention instead of MLA.
         num_dense_layers=0,
         # ------------------------------------------------
+        # Modified: Parameters for decomposed FFNs.
+        use_decomp_mlp=False,
+        ffn_rank=None,
+        # ------------------------------------------------
         **kwargs,
     ):
         super().__init__(pad_token_id=pad_token_id, **kwargs)
@@ -163,6 +167,11 @@ class SubspaceBertConfig(PretrainedConfig):
         # When using MLA, the first `num_dense_layers` will still use
         # standard MHA. This mirrors practices from some MoE models.
         self.num_dense_layers = num_dense_layers
+        # ------------------------------------------------
+        # Modified: Store decomposed FFN settings.
+        self.use_decomp_mlp = use_decomp_mlp
+        # Allow legacy name `ffn_rank` for the latent dimension.
+        self.ffn_rank = ffn_rank if ffn_rank is not None else hidden_size
         # ------------------------------------------------
 
 

--- a/encoder-pretrain/models/custom_bert.py
+++ b/encoder-pretrain/models/custom_bert.py
@@ -573,6 +573,31 @@ class BertIntermediate(nn.Module):
         return hidden_states
 
 
+class BertIntermediateDecomp(nn.Module):
+    """Decomposed variant of the intermediate feed-forward projection."""
+
+    def __init__(self, config):
+        super().__init__()
+        latent_dim = getattr(config, "ffn_rank", None)
+        if latent_dim is None:
+            latent_dim = config.intermediate_size
+
+        # Shared input projection then per-neuron expansion
+        self.w1a = nn.Linear(config.hidden_size, latent_dim, bias=False)
+        self.w1b = nn.Linear(latent_dim, config.intermediate_size)
+
+        if isinstance(config.hidden_act, str):
+            self.intermediate_act_fn = ACT2FN[config.hidden_act]
+        else:
+            self.intermediate_act_fn = config.hidden_act
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        hidden_states = self.w1a(hidden_states)
+        hidden_states = self.w1b(hidden_states)
+        hidden_states = self.intermediate_act_fn(hidden_states)
+        return hidden_states
+
+
 class BertOutput(nn.Module):
     def __init__(self, config):
         super().__init__()
@@ -582,6 +607,29 @@ class BertOutput(nn.Module):
 
     def forward(self, hidden_states: torch.Tensor, input_tensor: torch.Tensor) -> torch.Tensor:
         hidden_states = self.dense(hidden_states)
+        hidden_states = self.dropout(hidden_states)
+        hidden_states = self.LayerNorm(hidden_states + input_tensor)
+        return hidden_states
+
+
+class BertOutputDecomp(nn.Module):
+    """Decomposed variant of the FFN output projection."""
+
+    def __init__(self, config):
+        super().__init__()
+        latent_dim = getattr(config, "ffn_rank", None)
+        if latent_dim is None:
+            latent_dim = config.intermediate_size
+
+        self.w2a = nn.Linear(config.intermediate_size, latent_dim, bias=False)
+        self.w2b = nn.Linear(latent_dim, config.hidden_size)
+
+        self.LayerNorm = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+        self.dropout = nn.Dropout(config.hidden_dropout_prob)
+
+    def forward(self, hidden_states: torch.Tensor, input_tensor: torch.Tensor) -> torch.Tensor:
+        hidden_states = self.w2a(hidden_states)
+        hidden_states = self.w2b(hidden_states)
         hidden_states = self.dropout(hidden_states)
         hidden_states = self.LayerNorm(hidden_states + input_tensor)
         return hidden_states
@@ -599,8 +647,13 @@ class BertLayer(GradientCheckpointingLayer):
             if not self.is_decoder:
                 raise ValueError(f"{self} should be used as a decoder model if cross attention is added")
             self.crossattention = BertAttention(config, position_embedding_type="absolute")
-        self.intermediate = BertIntermediate(config)
-        self.output = BertOutput(config)
+        if getattr(config, "use_decomp_mlp", False):
+            # Use decomposed feed-forward network.
+            self.intermediate = BertIntermediateDecomp(config)
+            self.output = BertOutputDecomp(config)
+        else:
+            self.intermediate = BertIntermediate(config)
+            self.output = BertOutput(config)
 
     def forward(
         self,

--- a/encoder-pretrain/tests/test_sanity.py
+++ b/encoder-pretrain/tests/test_sanity.py
@@ -188,6 +188,28 @@ def test_mla_with_dense_prefix_layers():
     )
 
 
+def test_decomposed_ffn():
+    """Ensure decomposed FFN modules can replace dense ones."""
+    config = SubspaceBertConfig(
+        vocab_size=100,
+        hidden_size=32,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        intermediate_size=64,
+        use_decomp_mlp=True,
+        ffn_rank=16,
+    )
+    config._attn_implementation = "eager"
+    model = SubspaceBertForMaskedLM(config)
+
+    assert hasattr(model.bert.encoder.layer[0], "intermediate")
+    assert model.bert.encoder.layer[0].intermediate.__class__.__name__ == "BertIntermediateDecomp"
+
+    input_ids = torch.randint(0, config.vocab_size, (2, 8))
+    outputs = model(input_ids=input_ids)
+    assert outputs.logits.shape == (2, 8, config.vocab_size)
+
+
 if __name__ == "__main__":
     print("Testing standard BERT forward")
     test_custom_bert_forward()


### PR DESCRIPTION
## Summary
- add parameters for decomposed FFN support to the configuration
- implement `BertIntermediateDecomp` and `BertOutputDecomp`
- allow `BertLayer` to use the decomposed FFN when requested
- test that decomposed FFNs work

## Testing
- `pytest -q encoder-pretrain/tests/test_sanity.py::test_decomposed_ffn -q`
- `pytest -q encoder-pretrain/tests/test_sanity.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6889769fb300832a9236538b5546c76f