### PR TITLE
Add debug prints for dense layer config

### DIFF
--- a/encoder-pretrain/models/configuration_bert.py
+++ b/encoder-pretrain/models/configuration_bert.py
@@ -174,6 +174,19 @@ class SubspaceBertConfig(PretrainedConfig):
         self.ffn_rank = ffn_rank if ffn_rank is not None else hidden_size
         # ------------------------------------------------
 
+        # ------------------------------------------------
+        # Modified: Print out key configuration settings so
+        # we can track how options like `num_dense_layers`
+        # are being passed around during initialization.
+        print(
+            "SubspaceBertConfig initialized with "
+            f"num_hidden_layers={self.num_hidden_layers}, "
+            f"use_mla={self.use_mla}, "
+            f"num_dense_layers={self.num_dense_layers}, "
+            f"use_decomp_mlp={self.use_decomp_mlp}"
+        )
+        # ------------------------------------------------
+
 
 class SubspaceBertOnnxConfig(OnnxConfig):
     @property

--- a/encoder-pretrain/models/custom_bert.py
+++ b/encoder-pretrain/models/custom_bert.py
@@ -733,6 +733,21 @@ class BertEncoder(nn.Module):
         # -------------------------------------------------
         # Modified: Allow using standard MHA for the first
         # `num_dense_layers` even when MLA is enabled.
+        # Also print out the layer setup so we can easily
+        # verify that the configuration is being applied
+        # correctly. This project is still in early
+        # development, so simple print statements help
+        # us debug the configuration flow.
+        dense_mlp_desc = (
+            "decomposed MLPs" if config.use_decomp_mlp else "dense MLPs"
+        )
+        num_dense = getattr(config, "num_dense_layers", 0)
+        num_mla = config.num_hidden_layers - num_dense
+        attn_desc = "MLA" if config.use_mla else "MHA"
+        print(
+            f"Initializing {num_dense} dense layers with MHA and {dense_mlp_desc}, "
+            f"and {num_mla} {attn_desc} layers with {dense_mlp_desc}"
+        )
         self.layer = nn.ModuleList()
         for idx in range(config.num_hidden_layers):
             # Create a copy of the config so each layer can have
@@ -745,6 +760,10 @@ class BertEncoder(nn.Module):
                 layer_cfg.use_mla = False
             else:
                 layer_cfg.use_mla = config.use_mla
+
+            print(
+                f"  Layer {idx}: use_mla={layer_cfg.use_mla}, use_decomp_mlp={layer_cfg.use_decomp_mlp}"
+            )
 
             self.layer.append(BertLayer(layer_cfg))
         # -------------------------------------------------


### PR DESCRIPTION
## Summary
- instrument the custom BERT encoder to print which layers use MLA
- print configuration details when creating `SubspaceBertConfig`

## Testing
- `pytest -q` *(fails: test_mla_with_dense_prefix_layers)*

------
https://chatgpt.com/codex/tasks/task_e_68897f5fe7ec832ab59b9481cea4263d