### PR TITLE
Refactor parameter summary into utility

### DIFF
--- a/encoder-pretrain/scripts/sanity_check.py
+++ b/encoder-pretrain/scripts/sanity_check.py
@@ -5,6 +5,7 @@ import os
 
 
 from models.custom_bert import SubspaceBertForMaskedLM, SubspaceBertConfig
+from utils import summarize_parameters, format_size
 
 # Load model from your training checkpoint directory
 
@@ -32,90 +33,10 @@ model = SubspaceBertForMaskedLM.from_pretrained(
 )
 model.eval()
 
-"""**Helper Function for Formatting Counts**"""
-
-def format_size(num):
-    """
-    This function iterates through a list of suffixes ('K', 'M', 'B') and
-    divides the input number by 1024 until the absolute value of the number is
-    less than 1024. Then, it formats the number with the appropriate suffix and
-    returns the result. If the number is larger than "B", it uses 'T'.
-    """
-    suffixes = [' ', 'K', 'M', 'B'] # Return an empty space if it's less than 1K,
-                                    # this helps highlight the larger values.
-
-    base = 1024
-
-    for suffix in suffixes:
-        if abs(num) < base:
-            if num % 1 != 0:
-                return f"{num:.2f}{suffix}"
-
-            else:
-                return f"{num:.0f}{suffix}"
-
-        num /= base
-
-    # Use "T" for anything larger.
-    if num % 1 != 0:
-        return f"{num:.2f}T"
-
-    else:
-        return f"{num:.0f}T"
-
 print("\n======== Parameters ========")
 
-## Get all of the model's parameters as a list of tuples.
-params = list(model.named_parameters())
-
-print('The model has {:} different named parameters.\n'.format(len(params)))
-
-# =====================
-#     Review Params
-# =====================
-
-total_params = 0
-for p_name, p in params:
-    total_params += p.numel()
-
-print("=============================\n")
-
-"""## Full Parameter List"""
-
-display_bias = True # Excludes any 1-D parameters.
-
-include_layers = []
-
-print("Parameter Name                                              Dimensions       Total Values    Trainable\n")
-
-for p_name, p in params:
-
-    # Loop through the parameter dimensions and delete any == 1.
-    p_size = list(p.size())
-
-    for i in range(len(p_size) - 1, -1, -1):
-        if p_size[i] == 1:
-            del p_size[i]
-
-    if len(p_size) == 1:
-        if not display_bias:
-            continue
-        p_dims = "{:>10,} x {:<10}".format(p.size()[0], "-")
-
-    elif len(p_size) == 2:
-        p_dims = "{:>10,} x {:<10,}".format(p.size()[0], p.size()[1])
-    elif len(p_size) == 3:
-        p_dims = "{:>10,} x {:,} x {:<10}".format(p.size()[0], p.size()[1], p.size()[2])
-    elif len(p_size) == 4:
-        p_dims = "{:>10,} x {:,} x {:,} x {:<10}".format(p.size()[0], p.size()[1], p.size()[2], p.size()[3])
-    else:
-        print("Unexpected: ", p.size(), p_name)
-        break
-
-    print("{:<55} {:}    {:>6}    {:}".format(p_name, p_dims, format_size(p.numel()), p.requires_grad))
-
-
-print(f"\nTotal elements: {format_size(total_params)}\n")
+# Use the shared utility to list model parameters and dimensions
+summarize_parameters(model)
 
 
 

--- a/encoder-pretrain/scripts/train.py
+++ b/encoder-pretrain/scripts/train.py
@@ -38,6 +38,7 @@ else:
 
 # This file exists in the 'scripts' subdirectory, go up a level to find 'models'.
 from models.custom_bert import SubspaceBertForMaskedLM, SubspaceBertConfig
+from utils import summarize_parameters, format_size
 
 # Make sure we can import modules from the encoder-pretrain package
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
@@ -57,36 +58,7 @@ def parse_args():
     parser.add_argument("--config", required=True, help="Path to JSON config")
     return parser.parse_args()
 
-"""**Helper Function for Formatting Counts**"""
-
-def format_size(num):
-    """
-    This function iterates through a list of suffixes ('K', 'M', 'B') and
-    divides the input number by 1024 until the absolute value of the number is
-    less than 1024. Then, it formats the number with the appropriate suffix and
-    returns the result. If the number is larger than "B", it uses 'T'.
-    """
-    suffixes = [' ', 'K', 'M', 'B'] # Return an empty space if it's less than 1K,
-                                    # this helps highlight the larger values.
-
-    base = 1024
-
-    for suffix in suffixes:
-        if abs(num) < base:
-            if num % 1 != 0:
-                return f"{num:.2f}{suffix}"
-
-            else:
-                return f"{num:.0f}{suffix}"
-
-        num /= base
-
-    # Use "T" for anything larger.
-    if num % 1 != 0:
-        return f"{num:.2f}T"
-
-    else:
-        return f"{num:.0f}T"
+"""Helper utilities are imported from utils."""
 
 
 
@@ -208,48 +180,14 @@ def main():
 
     print(f"Total elements: {cfg['total_elements']}\n")
 
-    # Print out final config
+    # Print out final config for quick verification
     for k, v in cfg.items():
         print(f"{k:>25}: {v:>10}")
-  
+
     print("=============================\n")
 
-    """## Full Parameter List"""
-
-    display_bias = True # Excludes any 1-D parameters.
-
-    include_layers = []
-
-    print("Parameter Name                                              Dimensions       Total Values    Trainable\n")
-
-    for p_name, p in params:
-
-        # Loop through the parameter dimensions and delete any == 1.
-        p_size = list(p.size())
-
-        for i in range(len(p_size) - 1, -1, -1):
-            if p_size[i] == 1:
-                del p_size[i]
-
-        if len(p_size) == 1:
-            if not display_bias:
-                continue
-            p_dims = "{:>10,} x {:<10}".format(p.size()[0], "-")
-
-        elif len(p_size) == 2:
-            p_dims = "{:>10,} x {:<10,}".format(p.size()[0], p.size()[1])
-        elif len(p_size) == 3:
-            p_dims = "{:>10,} x {:,} x {:<10}".format(p.size()[0], p.size()[1], p.size()[2])
-        elif len(p_size) == 4:
-            p_dims = "{:>10,} x {:,} x {:,} x {:<10}".format(p.size()[0], p.size()[1], p.size()[2], p.size()[3])
-        else:
-            print("Unexpected: ", p.size(), p_name)
-            break
-
-        print("{:<55} {:}    {:>6}    {:}".format(p_name, p_dims, format_size(p.numel()), p.requires_grad))
-
-
-    print(f"\nTotal elements: {format_size(total_params)}\n")
+    # Display a full parameter breakdown using the shared utility
+    summarize_parameters(model)
 
 
     # ========================================

--- a/encoder-pretrain/utils.py
+++ b/encoder-pretrain/utils.py
@@ -1,0 +1,64 @@
+# Utility helpers for experiments
+
+from typing import Iterable, Tuple
+import torch.nn as nn
+
+
+def format_size(num: int) -> str:
+    """Return a human readable string for the given integer."""
+    suffixes = [" ", "K", "M", "B"]
+    base = 1024
+    for suffix in suffixes:
+        if abs(num) < base:
+            if num % 1 != 0:
+                return f"{num:.2f}{suffix}"
+            else:
+                return f"{num:.0f}{suffix}"
+        num /= base
+    if num % 1 != 0:
+        return f"{num:.2f}T"
+    return f"{num:.0f}T"
+
+
+def summarize_parameters(model: nn.Module, display_bias: bool = True) -> int:
+    """Print a table of parameter names, shapes and counts."""
+    params: Iterable[Tuple[str, nn.Parameter]] = list(model.named_parameters())
+    print("The model has {:} different named parameters.\n".format(len(params)))
+
+    total_params = 0
+    for _, p in params:
+        total_params += p.numel()
+
+    print(f"Total elements: {format_size(total_params)}\n")
+    print(
+        "Parameter Name                                              Dimensions       Total Values    Trainable\n"
+    )
+
+    for p_name, p in params:
+        p_size = list(p.size())
+        for i in range(len(p_size) - 1, -1, -1):
+            if p_size[i] == 1:
+                del p_size[i]
+        if len(p_size) == 1:
+            if not display_bias:
+                continue
+            p_dims = "{:>10,} x {:<10}".format(p.size()[0], "-")
+        elif len(p_size) == 2:
+            p_dims = "{:>10,} x {:<10,}".format(p.size()[0], p.size()[1])
+        elif len(p_size) == 3:
+            p_dims = "{:>10,} x {:,} x {:<10}".format(p.size()[0], p.size()[1], p.size()[2])
+        elif len(p_size) == 4:
+            p_dims = "{:>10,} x {:,} x {:,} x {:<10}".format(
+                p.size()[0], p.size()[1], p.size()[2], p.size()[3]
+            )
+        else:
+            print("Unexpected: ", p.size(), p_name)
+            break
+        print(
+            "{:<55} {:}    {:>6}    {:}".format(
+                p_name, p_dims, format_size(p.numel()), p.requires_grad
+            )
+        )
+
+    print(f"\nTotal elements: {format_size(total_params)}\n")
+    return total_params

--- a/reference/vit_with_shared_output_subspace.py
+++ b/reference/vit_with_shared_output_subspace.py
@@ -554,6 +554,7 @@ from torch.utils.data import DataLoader
 from torch.optim.lr_scheduler import CosineAnnealingLR
 import timm
 from tqdm import tqdm
+from utils import summarize_parameters, format_size
 
 print(f"PyTorch version: {torch.__version__}")
 print(f"timm version: {timm.__version__}")
@@ -578,36 +579,7 @@ wandb_key = userdata.get('wandb_api_key')
 # Authenticate with wandb
 wandb.login(key=wandb_key)
 
-"""**Helper Function for Formatting Counts**"""
-
-def format_size(num):
-    """
-    This function iterates through a list of suffixes ('K', 'M', 'B') and
-    divides the input number by 1024 until the absolute value of the number is
-    less than 1024. Then, it formats the number with the appropriate suffix and
-    returns the result. If the number is larger than "B", it uses 'T'.
-    """
-    suffixes = [' ', 'K', 'M', 'B'] # Return an empty space if it's less than 1K,
-                                    # this helps highlight the larger values.
-
-    base = 1024
-
-    for suffix in suffixes:
-        if abs(num) < base:
-            if num % 1 != 0:
-                return f"{num:.2f}{suffix}"
-
-            else:
-                return f"{num:.0f}{suffix}"
-
-        num /= base
-
-    # Use "T" for anything larger.
-    if num % 1 != 0:
-        return f"{num:.2f}T"
-
-    else:
-        return f"{num:.0f}T"
+"""Helper utilities are imported from utils."""
 
 """## Model"""
 
@@ -818,41 +790,7 @@ run_name = f"{config['total_elements']} - {mlp_str} - {attn_str} - l{config['dep
 
 print(run_name)
 
-"""## Full Parameter List"""
-
-display_bias = True # Excludes any 1-D parameters.
-
-
-print("Parameter Name                                              Dimensions       Total Values    Trainable\n")
-
-for p_name, p in params:
-
-    # Loop through the parameter dimensions and delete any == 1.
-    p_size = list(p.size())
-
-    for i in range(len(p_size) - 1, -1, -1):
-        if p_size[i] == 1:
-            del p_size[i]
-
-    if len(p_size) == 1:
-        if not display_bias:
-            continue
-        p_dims = "{:>10,} x {:<10}".format(p.size()[0], "-")
-
-    elif len(p_size) == 2:
-        p_dims = "{:>10,} x {:<10,}".format(p.size()[0], p.size()[1])
-    elif len(p_size) == 3:
-        p_dims = "{:>10,} x {:,} x {:<10}".format(p.size()[0], p.size()[1], p.size()[2])
-    elif len(p_size) == 4:
-        p_dims = "{:>10,} x {:,} x {:,} x {:<10}".format(p.size()[0], p.size()[1], p.size()[2], p.size()[3])
-    else:
-        print("Unexpected: ", p.size(), p_name)
-        break
-
-    print("{:<55} {:}    {:>6}    {:}".format(p_name, p_dims, format_size(p.numel()), p.requires_grad))
-
-
-print(f"\nTotal elements: {format_size(total_params)}\n")
+summarize_parameters(model)
 
 """# ▂▂▂▂▂▂▂▂▂▂▂▂
 


### PR DESCRIPTION
## Summary
- add `utils.summarize_parameters` for printing model parameters
- replace duplicated blocks in training and sanity scripts with new helper
- use the same helper in the ViT reference script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889940bacfc832a93ce971fbee490ea