### PR TITLE
Add profiling script and fix feedforward dimensions

### DIFF
--- a/encoder-pretrain/configs/mla.json
+++ b/encoder-pretrain/configs/mla.json
@@ -25,8 +25,6 @@
   "v_head_dim": 32,
   "qk_nope_head_dim": 32,
 
-  "use_output_latent": false,
-  
   "fp16": true,
   
   "train_batch_size": 64,

--- a/encoder-pretrain/configs/mla_output.json
+++ b/encoder-pretrain/configs/mla_output.json
@@ -25,7 +25,7 @@
   "v_head_dim": 32,
   "qk_nope_head_dim": 32,
 
-  "use_output_latent": true,
+  "output_subspace": true,
   
   "fp16": true,
   
@@ -44,7 +44,6 @@
   "output_dir": "checkpoints/mla_w_output",
   
   "use_mla": true,
-  
-  "output_subspace": false,
+
   "ffn_decompose": false
 }

--- a/encoder-pretrain/configs/mla_w_dense.json
+++ b/encoder-pretrain/configs/mla_w_dense.json
@@ -25,8 +25,6 @@
   "v_head_dim": 32,
   "qk_nope_head_dim": 32,
 
-  "use_output_latent": false,
-  
   "fp16": true,
   
   "train_batch_size": 64,

--- a/encoder-pretrain/models/configuration_bert.py
+++ b/encoder-pretrain/models/configuration_bert.py
@@ -121,7 +121,7 @@ class SubspaceBertConfig(PretrainedConfig):
         qk_rope_head_dim=None,
         v_head_dim=None,
         qk_nope_head_dim=0,
-        add_output_latent=False,
+        output_subspace=False,
         o_lora_rank=None,
         # ------------------------------------------------
         # Modified: Number of initial layers that use dense
@@ -129,7 +129,7 @@ class SubspaceBertConfig(PretrainedConfig):
         num_dense_layers=0,
         # ------------------------------------------------
         # Modified: Parameters for decomposed FFNs.
-        use_decomp_mlp=False,
+        ffn_decompose=False,
         ffn_rank=None,
         # ------------------------------------------------
         **kwargs,
@@ -162,14 +162,18 @@ class SubspaceBertConfig(PretrainedConfig):
         )
         self.v_head_dim = v_head_dim if v_head_dim is not None else hidden_size // num_attention_heads
         self.qk_nope_head_dim = qk_nope_head_dim
-        self.add_output_latent = add_output_latent
+        self.output_subspace = output_subspace
+        # Maintain backwards compatibility
+        self.add_output_latent = output_subspace
         self.o_lora_rank = o_lora_rank if o_lora_rank is not None else hidden_size
         # When using MLA, the first `num_dense_layers` will still use
         # standard MHA. This mirrors practices from some MoE models.
         self.num_dense_layers = num_dense_layers
         # ------------------------------------------------
         # Modified: Store decomposed FFN settings.
-        self.use_decomp_mlp = use_decomp_mlp
+        self.ffn_decompose = ffn_decompose
+        # Backwards compatibility
+        self.use_decomp_mlp = ffn_decompose
         # Allow legacy name `ffn_rank` for the latent dimension.
         self.ffn_rank = ffn_rank if ffn_rank is not None else hidden_size
         # ------------------------------------------------
@@ -183,7 +187,7 @@ class SubspaceBertConfig(PretrainedConfig):
             f"  num_hidden_layers={self.num_hidden_layers}\n"
             f"            use_mla={self.use_mla}\n"
             f"   num_dense_layers={self.num_dense_layers}\n"
-            f"     use_decomp_mlp={self.use_decomp_mlp}\n"
+            f"   ffn_decompose={self.ffn_decompose}\n"
         )
         # ------------------------------------------------
 

--- a/encoder-pretrain/models/custom_bert.py
+++ b/encoder-pretrain/models/custom_bert.py
@@ -490,7 +490,7 @@ class BertAttention(nn.Module):
                 v_head_dim=config.v_head_dim,
                 qk_nope_head_dim=config.qk_nope_head_dim,
 
-                use_output_latent=config.add_output_latent,
+                output_subspace=config.output_subspace,
                 o_lora_rank=config.o_lora_rank,
 
                 max_position_embeddings=config.max_position_embeddings,
@@ -596,7 +596,7 @@ class BertOutput(nn.Module):
     def __init__(self, config):
         super().__init__()
         
-        self.dense = nn.Linear(config.hidden_size, config.hidden_size)        
+        self.dense = nn.Linear(config.intermediate_size, config.hidden_size)        
         self.LayerNorm = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
         self.dropout = nn.Dropout(config.hidden_dropout_prob)
 
@@ -668,7 +668,7 @@ class BertLayer(GradientCheckpointingLayer):
             if not self.is_decoder:
                 raise ValueError(f"{self} should be used as a decoder model if cross attention is added")
             self.crossattention = BertAttention(config, position_embedding_type="absolute")
-        if config.use_decomp_mlp:
+        if config.ffn_decompose:
             # Use decomposed feed-forward network.
             print("      > adding decomp mlp")
             self.intermediate = BertIntermediateDecomp(config)
@@ -769,7 +769,7 @@ class BertEncoder(nn.Module):
             f"\n==== BertEncoder ====\n"
             f"  - dense layers: {num_dense}\n"
             f"  - mla? {config.use_mla}\n"
-            f"  - decomps? {config.use_decomp_mlp}\n"
+            f"  - decomps? {config.ffn_decompose}\n"
             f"  Layers:\n"
         )
 
@@ -787,7 +787,7 @@ class BertEncoder(nn.Module):
                 layer_cfg.use_mla = config.use_mla
 
             print(
-                f"    > Layer {idx}: mla? {layer_cfg.use_mla} dcmp? {layer_cfg.use_decomp_mlp}"
+                f"    > Layer {idx}: mla? {layer_cfg.use_mla} dcmp? {layer_cfg.ffn_decompose}"
             )
 
             self.layer.append(BertLayer(layer_cfg))
@@ -871,6 +871,9 @@ class BertEncoder(nn.Module):
 class BertPooler(nn.Module):
     def __init__(self, config):
         super().__init__()
+        # Standard BERT FFN output projects from intermediate_size back to
+        # hidden_size. The previous version incorrectly used hidden_size for
+        # both dimensions, which caused shape mismatches in tests.
         self.dense = nn.Linear(config.hidden_size, config.hidden_size)
         self.activation = nn.Tanh()
 

--- a/encoder-pretrain/models/layers/configuration_deepseek_v3.py
+++ b/encoder-pretrain/models/layers/configuration_deepseek_v3.py
@@ -172,7 +172,8 @@ class DeepseekV3Config(PretrainedConfig):
         
         # ------------------------------------------------
         # Modified: Support additional output latent space
-        use_output_latent=False,
+        output_subspace=False,
+        use_output_latent=None,
         o_lora_rank=1536,
         # ------------------------------------------------
         
@@ -216,10 +217,12 @@ class DeepseekV3Config(PretrainedConfig):
         # ------------------------------------------------
         # Modified: store output latent options on the config
         # so they don't need to be manually overridden later.
-        self.use_output_latent = use_output_latent
+        if use_output_latent is not None:
+            output_subspace = use_output_latent
+        self.output_subspace = output_subspace
         # Keep backwards compatibility with older code that
         # checks `add_output_latent`.
-        self.add_output_latent = use_output_latent
+        self.add_output_latent = output_subspace
         self.o_lora_rank = o_lora_rank
         # ------------------------------------------------
         self.qk_head_dim = qk_nope_head_dim + qk_rope_head_dim

--- a/encoder-pretrain/scripts/train_profiler.py
+++ b/encoder-pretrain/scripts/train_profiler.py
@@ -1,10 +1,11 @@
-print("Importing Packages...\n")
-
 import json
 import argparse
 from pathlib import Path
 import sys
 import os
+
+import torch
+from torch import profiler as torch_profiler
 
 import wandb
 from datasets import load_dataset
@@ -17,34 +18,12 @@ from transformers import (
     set_seed,
 )
 
-print("\n===== DEBUG: File Context =====")
-print("Current Working Directory:", os.getcwd())
-print("Script __file__:", __file__)
-print("sys.path:")
-for p in sys.path:
-    print("  ", p)
-
-print("\nList of files in CWD:")
-for f in os.listdir():
-    print("  ", f)
-
-print("\nList of files in 'models/' relative to CWD:")
-models_path = os.path.join(os.getcwd(), "models")
-if os.path.isdir(models_path):
-    for f in os.listdir(models_path):
-        print("  ", f)
-else:
-    print("  (models/ directory not found)")
-
 # This file exists in the 'scripts' subdirectory, go up a level to find 'models'.
 from models.custom_bert import SubspaceBertForMaskedLM, SubspaceBertConfig
 from utils import summarize_parameters, format_size
 
 # Make sure we can import modules from the encoder-pretrain package
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
-
-print("PROJECT_ROOT", PROJECT_ROOT)
-
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
@@ -72,6 +51,8 @@ def main():
     # of the script can rely on a consistent set of fields.
     cfg["ffn_decompose"] = cfg.get("ffn_decompose", cfg.get("use_decomp_mlp", False))
     cfg["output_subspace"] = cfg.get("output_subspace", cfg.get("use_output_latent", False))
+    # Default max_steps for profiling; keeps runs short unless overridden
+    cfg["max_steps"] = cfg.get("max_steps", 10)
 
     print("Transformers version:", transformers.__version__)  # Helpful sanity check
 
@@ -267,6 +248,8 @@ def main():
         
         learning_rate=cfg["learning_rate"],
         num_train_epochs=cfg["num_train_epochs"],
+        # Limit steps for profiling so execution finishes quickly
+        max_steps=cfg.get("max_steps", 10),
         
         # Evaluate every xx steps
         # Recent versions changed from 'evaluation_strategy'
@@ -304,7 +287,17 @@ def main():
     # =====================
 
     try:
-        trainer.train()
+        # Profile the training run to collect performance information.
+        # The context records all operations executed by `trainer.train`.
+        with torch_profiler.profile(
+            activities=[torch_profiler.ProfilerActivity.CPU],
+            record_shapes=True,
+        ) as prof:
+            trainer.train()
+
+        # Display a summary of the profiling results.
+        print(prof.key_averages().table(sort_by="cpu_time_total", row_limit=10))
+
         metrics = trainer.evaluate()
         wandb.log(metrics)
     

--- a/encoder-pretrain/tests/test_sanity.py
+++ b/encoder-pretrain/tests/test_sanity.py
@@ -79,7 +79,7 @@ def test_deepseek_attention_with_output_latent():
         max_position_embeddings=16,
         attention_dropout=0.0,
         rms_norm_eps=1e-6,
-        use_output_latent=True,
+        output_subspace=True,
         o_lora_rank=32,
     )
     ds_config._attn_implementation = "eager"
@@ -140,7 +140,7 @@ def test_custom_bert_with_mla():
     )
     config._attn_implementation = "eager" # Allows for manual implementation.
     config.use_mla = True # Use this to choose MLA instead.
-    config.add_output_latent = False
+    config.output_subspace = False
     model = SubspaceBertForMaskedLM(config)
     input_ids = torch.randint(0, config.vocab_size, (2, 8))
     outputs = model(input_ids=input_ids)
@@ -157,7 +157,7 @@ def test_custom_bert_with_mla_output_latent():
     )
     config._attn_implementation = "eager" # Allows for manual implementation.
     config.use_mla = True # Use this to choose MLA instead.
-    config.add_output_latent = True
+    config.output_subspace = True
     model = SubspaceBertForMaskedLM(config)
     input_ids = torch.randint(0, config.vocab_size, (2, 8))
     outputs = model(input_ids=input_ids)
@@ -196,7 +196,7 @@ def test_decomposed_ffn():
         num_hidden_layers=6,
         num_attention_heads=4,
         intermediate_size=64,
-        use_decomp_mlp=True,
+        ffn_decompose=True,
         ffn_rank=16,
         num_dense_layers=2
     )


### PR DESCRIPTION
## Summary
- fix feed-forward output layer dimensions in `custom_bert.py`
- add `train_profiler.py` script with a basic PyTorch profiling setup
- clean up profiling script and standardize configuration field names

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889987a2cc8832a801244457e04a5f9