### PR TITLE
Use JSON config base in tests

### DIFF
--- a/encoder-pretrain/tests/test_config.json
+++ b/encoder-pretrain/tests/test_config.json
@@ -1,0 +1,76 @@
+{
+  "shorthand": "mla.64.48.64, dense.2, dcmp.1024.xxx, model.d256.l6, ah.8.32",
+  
+  "notes": "Will be used as part of a sweep over FFN decomposition ranks.",
+  
+  "model": {	
+	"hidden_size":          256,
+    "num_hidden_layers":    6,
+    "intermediate_size":    1024,
+    "hidden_act":           "gelu",
+    
+    "use_mla":           true,
+	
+	"num_dense_layers":  2,	
+    "q_lora_rank":       64,
+    "kv_lora_rank":      48,
+	
+	"num_attention_heads":  8,
+    "v_head_dim":           32,
+	"attention_bias":       false,	
+	
+	"output_subspace":   true,
+    "o_lora_rank":       64,
+	
+    "attention_backend": "sdpa",
+
+    "ffn_decompose":     true,
+    "ffn_rank":          128,
+
+	"hidden_dropout_prob":  0.1,
+    "attention_dropout_prob": 0.1,
+    "classifier_dropout":   null,
+    
+	"use_cache":            true,
+    
+    "initializer_range":    0.02,
+    "layer_norm_eps":       1e-12,
+
+    "vocab_size":           30522,
+    "type_vocab_size":      2,
+    "pad_token_id":         0,
+	"rope_theta":           10000.0,
+    "rope_scaling":         null,
+    "rope_interleave":      false,
+    "position_embedding_type":  "absolute",
+	"max_position_embeddings":  128,
+    "qk_rope_head_dim":  16,
+    "qk_nope_head_dim":  32
+  },
+  
+  "pre_train": {
+    "output_dir":        "checkpoints/mla_output_decompose",
+	"seed":              42,
+	
+    "train_batch_size":  64,
+    "learning_rate":     5e-4,
+    "num_train_epochs":  3,
+	
+    "mlm_probability":   0.15,
+    "dataset_name":      "wikitext",
+    "dataset_config":    "wikitext-2-raw-v1",
+    
+	"max_seq_length":    128,
+	"eval_batch_size":   64,
+	
+    "fp16":              true
+  },
+  
+  "fine_tune": {
+    "task":         "sst2",
+	"batch_size":   16,
+	"lr":           2e-5,
+	"epochs":       3,
+	"max_length":   128
+  }
+}

--- a/encoder-pretrain/tests/test_sanity.py
+++ b/encoder-pretrain/tests/test_sanity.py
@@ -1,3 +1,4 @@
+import json
 import torch
 import pytest
 import sys
@@ -10,21 +11,43 @@ if str(PROJECT_ROOT) not in sys.path:
 from models.custom_bert import SubspaceBertForMaskedLM, SubspaceBertConfig
 from models.layers.mla_attention import (
     DeepseekV3Attention,
-    DeepseekV3Config,
     DeepseekV3RotaryEmbedding,
 )
+from transformers import DeepseekV3Config
+
+BASE_CONFIG = Path(__file__).resolve().with_name("test_config.json")
+
+
+def load_config(overrides=None):
+    """Load the base JSON config and apply any overrides."""
+    with open(BASE_CONFIG) as f:
+        cfg = json.load(f)
+
+    if "stats" not in cfg:
+        cfg["stats"] = {}
+
+    if overrides:
+        cfg["model"].update(overrides)
+
+    valid_keys = set(SubspaceBertConfig.__init__.__code__.co_varnames) - {"self", "kwargs"}
+    extra_keys = set(cfg["model"]) - valid_keys
+    if extra_keys:
+        raise ValueError(f"Unknown keys in config: {sorted(extra_keys)}")
+
+    return SubspaceBertConfig(**cfg["model"])
 
 
 def test_custom_bert_forward():
-    config = SubspaceBertConfig(
-        vocab_size=100,
-        hidden_size=32,
-        num_hidden_layers=2,
-        num_attention_heads=4,
-        intermediate_size=64,
-    )
-    # Use standard attention implementation
-    config._attn_implementation = "eager"
+    overrides = {
+        "vocab_size": 100,
+        "hidden_size": 32,
+        "num_hidden_layers": 2,
+        "num_attention_heads": 4,
+        "intermediate_size": 64,
+        "use_mla": False,
+        "attention_backend": "eager",
+    }
+    config = load_config(overrides)
     model = SubspaceBertForMaskedLM(config)
     # generate random input ids (batch_size=2, seq_len=8)
     input_ids = torch.randint(0, config.vocab_size, (2, 8))
@@ -48,6 +71,7 @@ def test_deepseek_attention_forward():
         attention_dropout_prob=0.0,
         rms_norm_eps=1e-6,
     )
+    ds_config.output_subspace = False
     ds_config._attn_implementation = "eager"
     attention = DeepseekV3Attention(ds_config, layer_idx=0)
 
@@ -82,6 +106,7 @@ def test_deepseek_attention_with_output_latent():
         use_output_latent=True,
         o_lora_rank=32,
     )
+    ds_config.output_subspace = True
     ds_config._attn_implementation = "eager"
     attention = DeepseekV3Attention(ds_config, layer_idx=0)
 
@@ -131,16 +156,17 @@ def test_deepseek_attention_flash():
 """
 
 def test_custom_bert_with_mla():
-    config = SubspaceBertConfig(
-        vocab_size=100,
-        hidden_size=32,
-        num_hidden_layers=2,
-        num_attention_heads=4,
-        intermediate_size=64,
-    )
-    config._attn_implementation = "eager" # Allows for manual implementation.
-    config.use_mla = True # Use this to choose MLA instead.
-    config.output_subspace = False
+    overrides = {
+        "vocab_size": 100,
+        "hidden_size": 32,
+        "num_hidden_layers": 2,
+        "num_attention_heads": 4,
+        "intermediate_size": 64,
+        "use_mla": True,
+        "output_subspace": False,
+        "attention_backend": "eager",
+    }
+    config = load_config(overrides)
     model = SubspaceBertForMaskedLM(config)
     input_ids = torch.randint(0, config.vocab_size, (2, 8))
     outputs = model(input_ids=input_ids)
@@ -148,16 +174,17 @@ def test_custom_bert_with_mla():
 
 
 def test_custom_bert_with_mla_output_latent():
-    config = SubspaceBertConfig(
-        vocab_size=100,
-        hidden_size=32,
-        num_hidden_layers=2,
-        num_attention_heads=4,
-        intermediate_size=64,
-    )
-    config._attn_implementation = "eager" # Allows for manual implementation.
-    config.use_mla = True # Use this to choose MLA instead.
-    config.output_subspace = True
+    overrides = {
+        "vocab_size": 100,
+        "hidden_size": 32,
+        "num_hidden_layers": 2,
+        "num_attention_heads": 4,
+        "intermediate_size": 64,
+        "use_mla": True,
+        "output_subspace": True,
+        "attention_backend": "eager",
+    }
+    config = load_config(overrides)
     model = SubspaceBertForMaskedLM(config)
     input_ids = torch.randint(0, config.vocab_size, (2, 8))
     outputs = model(input_ids=input_ids)
@@ -166,16 +193,17 @@ def test_custom_bert_with_mla_output_latent():
 
 def test_mla_with_dense_prefix_layers():
     """Ensure dense prefix layers fall back to standard MHA."""
-    config = SubspaceBertConfig(
-        vocab_size=100,
-        hidden_size=32,
-        num_hidden_layers=6,
-        num_attention_heads=4,
-        intermediate_size=64,
-        use_mla=True,
-        num_dense_layers=2,
-    )
-    config._attn_implementation = "eager"
+    overrides = {
+        "vocab_size": 100,
+        "hidden_size": 32,
+        "num_hidden_layers": 6,
+        "num_attention_heads": 4,
+        "intermediate_size": 64,
+        "use_mla": True,
+        "num_dense_layers": 2,
+        "attention_backend": "eager",
+    }
+    config = load_config(overrides)
     model = SubspaceBertForMaskedLM(config)
 
     # First layer should use standard attention
@@ -190,17 +218,18 @@ def test_mla_with_dense_prefix_layers():
 
 def test_decomposed_ffn():
     """Ensure decomposed FFN modules can replace dense ones."""
-    config = SubspaceBertConfig(
-        vocab_size=100,
-        hidden_size=32,
-        num_hidden_layers=6,
-        num_attention_heads=4,
-        intermediate_size=64,
-        use_decomp_mlp=True,
-        ffn_rank=16,
-        num_dense_layers=2
-    )
-    config._attn_implementation = "eager"
+    overrides = {
+        "vocab_size": 100,
+        "hidden_size": 32,
+        "num_hidden_layers": 6,
+        "num_attention_heads": 4,
+        "intermediate_size": 64,
+        "ffn_decompose": True,
+        "ffn_rank": 16,
+        "num_dense_layers": 2,
+        "attention_backend": "eager",
+    }
+    config = load_config(overrides)
     model = SubspaceBertForMaskedLM(config)
 
     # TODO - Confirm that the first two layers are still dense, e.g.


### PR DESCRIPTION
## Summary
- copy `mla_output_decompose.json` into tests as `test_config.json`
- add helper in tests to load this JSON using the same checks as `train.py`
- update test cases to override settings via the config
- fix DeepseekV3 imports and config attributes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a8c805ee0832a96f2b7b423d85491