### PR TITLE
Add configurable dataloader workers

### DIFF
--- a/encoder-pretrain/README.md
+++ b/encoder-pretrain/README.md
@@ -28,3 +28,14 @@ Available configs:
 - `mla_output_decompose.json` – MLA, output subspace and decomposed MLP.
 
 Training metrics are logged to wandb under the project `encoder-pretrain`.
+
+### Dataloader Settings
+
+Two optional fields in the `pre_train` section control how data loading is
+performed:
+
+- `num_workers` – number of worker processes used by the PyTorch dataloader.
+- `pin_memory` – whether to pin dataloader memory for faster host-to-device
+  transfers.
+
+If omitted, `num_workers` defaults to `0` and `pin_memory` defaults to `false`.

--- a/encoder-pretrain/scripts/train_profiler.py
+++ b/encoder-pretrain/scripts/train_profiler.py
@@ -41,15 +41,30 @@ def parse_args():
 
 from torch.utils.data import DataLoader
 
+
 class CustomTrainer(Trainer):
+    """Trainer with configurable DataLoader settings."""
+
+    def __init__(self, *args, config, **kwargs):
+        # Store the full experiment config so we can read DataLoader options.
+        super().__init__(*args, **kwargs)
+        self.config = config
+
+    def _dataloader_kwargs(self):
+        """Return kwargs controlling dataloader parallelism and memory usage."""
+        pre_cfg = self.config["pre_train"]
+        return {
+            "num_workers": pre_cfg.get("num_workers", 0),
+            "pin_memory": pre_cfg.get("pin_memory", False),
+        }
+
     def get_train_dataloader(self):
         return DataLoader(
             self.train_dataset,
             batch_size=self.args.train_batch_size,
             shuffle=True,
             collate_fn=self.data_collator,
-            num_workers=4,
-            pin_memory=True,
+            **self._dataloader_kwargs(),
         )
 
     def get_eval_dataloader(self, eval_dataset=None):
@@ -58,8 +73,7 @@ class CustomTrainer(Trainer):
             eval_dataset,
             batch_size=self.args.eval_batch_size,
             collate_fn=self.data_collator,
-            num_workers=4,
-            pin_memory=True,
+            **self._dataloader_kwargs(),
         )
 
 
@@ -304,7 +318,7 @@ def main():
         eval_dataset=tokenized["validation"],
         processing_class=tokenizer, # New argument name, allows for other modalities.
         data_collator=data_collator,
-        #config=config,
+        config=config,
     )
 
     # =====================


### PR DESCRIPTION
## Summary
- allow configuring dataloader parallelism in `train_profiler.py`
- document new `num_workers` and `pin_memory` config options

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688aa3a3e4f0832aaeb4fc2caeb0cd3f